### PR TITLE
Add missing .cargo/config from lanzaboote

### DIFF
--- a/rust/.cargo/config
+++ b/rust/.cargo/config
@@ -1,0 +1,2 @@
+[build]
+target = "x86_64-unknown-uefi"


### PR DESCRIPTION
This fixes the error on `cargo build` complaining about missing `eh_personality`